### PR TITLE
Release 0.1.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hopscotch"
-version = "0.1.3"
+version = "0.1.4"
 description = "Type-oriented registry with dependency injection."
 authors = ["Paul Everitt <pauleveritt@me.com>"]
 license = "MIT"


### PR DESCRIPTION
This release cleans up the `.github` actions for tests to match latest Hypermodern.