### PR TITLE
Inject fields with default_factory

### DIFF
--- a/examples/readme/context/__init__.py
+++ b/examples/readme/context/__init__.py
@@ -1,5 +1,6 @@
 """Replace a built-in class."""
 from dataclasses import dataclass
+
 from hopscotch import injectable
 from hopscotch import Registry
 

--- a/examples/readme/decorator/__init__.py
+++ b/examples/readme/decorator/__init__.py
@@ -1,5 +1,6 @@
 """Register with a decorator."""
 from dataclasses import dataclass
+
 from hopscotch import injectable
 from hopscotch import Registry
 

--- a/examples/readme/hello/__init__.py
+++ b/examples/readme/hello/__init__.py
@@ -1,5 +1,6 @@
 """Simplest possible example."""
 from dataclasses import dataclass
+
 from hopscotch import Registry
 
 

--- a/examples/readme/operators/__init__.py
+++ b/examples/readme/operators/__init__.py
@@ -1,5 +1,6 @@
 """Rich dependency injection with operators."""
 from dataclasses import dataclass
+
 from hopscotch import injectable
 from hopscotch import Registry
 from hopscotch.operators import get

--- a/examples/readme/replace/__init__.py
+++ b/examples/readme/replace/__init__.py
@@ -1,5 +1,6 @@
 """Replace a built-in class."""
 from dataclasses import dataclass
+
 from hopscotch import injectable
 from hopscotch import Registry
 

--- a/examples/readme/simple_di/__init__.py
+++ b/examples/readme/simple_di/__init__.py
@@ -1,5 +1,6 @@
 """Simple dependency injection."""
 from dataclasses import dataclass
+
 from hopscotch import injectable
 from hopscotch import Registry
 

--- a/src/hopscotch/field_infos.py
+++ b/src/hopscotch/field_infos.py
@@ -32,6 +32,7 @@ class FieldInfo(NamedTuple):
     field_name: str
     field_type: Optional[type]
     default_value: Optional[object] = None
+    default_factory: Optional[Callable[[], object]] = None
     operator: Optional[Operator] = None
     has_annotated: bool = False
     is_builtin: bool = False
@@ -82,6 +83,9 @@ def dataclass_field_info_factory(field_type: type, field: Field[Any]) -> FieldIn
 
     # Default values
     default_value = None if field.default is MISSING else field.default
+    default_factory = (
+        None if field.default_factory is MISSING else field.default_factory
+    )
 
     is_builtin = field_type.__module__ == "builtins" if field_type else False
 
@@ -89,6 +93,7 @@ def dataclass_field_info_factory(field_type: type, field: Field[Any]) -> FieldIn
         field_name=field.name,
         field_type=field_type,
         default_value=default_value,
+        default_factory=default_factory,
         operator=operator,
         has_annotated=has_annotated,
         is_builtin=is_builtin,

--- a/src/hopscotch/fixtures/__init__.py
+++ b/src/hopscotch/fixtures/__init__.py
@@ -1,5 +1,6 @@
 """Example objects for tests, examples, and docs."""
 from dataclasses import dataclass
+
 from hopscotch.registry import Registry
 
 

--- a/src/hopscotch/fixtures/dataklasses.py
+++ b/src/hopscotch/fixtures/dataklasses.py
@@ -3,14 +3,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from dataclasses import field
+from typing import Annotated
+from typing import Optional
+
 from hopscotch import injectable
 from hopscotch import Registry
 from hopscotch.operators import Context
 from hopscotch.operators import context
 from hopscotch.operators import Get
 from hopscotch.operators import get
-from typing import Annotated
-from typing import Optional
 
 
 # Decorate Greeting
@@ -42,6 +43,20 @@ class GreetingInitFalse:
     """A dataclass with a field that inits to false."""
 
     salutation: str = field(init=False)
+
+
+@dataclass()
+class GreetingFieldDefault:
+    """A dataclass with a field using a default argument."""
+
+    salutation: str = field(default="Default Argument")
+
+
+@dataclass()
+class GreetingFieldDefaultFactory:
+    """A dataclass with a field using a default factory."""
+
+    salutation: list = field(default_factory=list)
 
 
 @dataclass()

--- a/src/hopscotch/fixtures/functions.py
+++ b/src/hopscotch/fixtures/functions.py
@@ -1,8 +1,9 @@
 """Example objects and kinds implemented as functions."""
-from hopscotch.fixtures.dataklasses import Customer
-from hopscotch.operators import Get
 from typing import Annotated
 from typing import Optional
+
+from hopscotch.fixtures.dataklasses import Customer
+from hopscotch.operators import Get
 
 
 def Greeting(salutation: str = "Hello") -> str:

--- a/src/hopscotch/fixtures/init_caller_package/__init__.py
+++ b/src/hopscotch/fixtures/init_caller_package/__init__.py
@@ -3,8 +3,9 @@
 Used for testing caller_package and the branching that looks
 if the package has a __init__.py in it.
 """
-from hopscotch.callers import caller_package
 from typing import Any
+
+from hopscotch.callers import caller_package
 
 
 def make_call() -> Any:

--- a/src/hopscotch/registry.py
+++ b/src/hopscotch/registry.py
@@ -148,6 +148,8 @@ def inject_callable(
             if field_info.default_value is not None:
                 # ...try to get from default
                 field_value = field_info.default_value
+            elif field_info.default_factory is not None:
+                field_value = field_info.default_factory()
             else:
                 # ...otherwise, we failed injection.
                 ql = target.__qualname__  # type: ignore
@@ -368,7 +370,9 @@ class Registry:
 class injectable:  # noqa
     """``venusian`` decorator to register an injectable factory ."""
 
-    kind: Optional[Type[T]] = None  # Give subclasses a chance to give default, e.g. view
+    kind: Optional[
+        Type[T]
+    ] = None  # Give subclasses a chance to give default, e.g. view
 
     def __init__(
         self,

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -7,9 +7,8 @@ from dataclasses import dataclass
 from typing import cast
 
 import pytest
-
-from hopscotch import Registry
 from hopscotch import injectable
+from hopscotch import Registry
 from hopscotch.fixtures import dataklasses
 from hopscotch.fixtures.dataklasses import Customer
 from hopscotch.fixtures.dataklasses import FrenchCustomer
@@ -19,17 +18,23 @@ from hopscotch.fixtures.dataklasses import GreeterFrenchCustomer
 
 
 class View:
+    """A marker for an example custom injectable."""
+
     title: str
 
 
 # noinspection PyPep8Naming
-class view(injectable):
+class view(injectable):  # noqa: N801
+    """Custom decorator for custom injectable."""
+
     kind = View
 
 
 @view()
 @dataclass
 class MyView(View):
+    """An example view."""
+
     title: str = "My View"
 
 
@@ -67,8 +72,9 @@ def test_injectable_explicit_context() -> None:
         registry2.get(GreeterFrenchCustomer)
 
 
-def test_custom_decorator():
+def test_custom_decorator() -> None:
+    """Test the custom decorator."""
     registry = Registry()
     registry.scan()
     result = cast(MyView, registry.get(View))
-    assert 'My View' == result.title
+    assert "My View" == result.title

--- a/tests/test_field_infos.py
+++ b/tests/test_field_infos.py
@@ -1,5 +1,7 @@
 """Test the field discovery functions for various targets."""
 import typing
+
+import pytest
 from hopscotch import Registry
 from hopscotch.field_infos import FieldInfo
 from hopscotch.field_infos import get_dataclass_field_infos
@@ -18,8 +20,6 @@ from hopscotch.fixtures.dataklasses import GreetingOperator
 from hopscotch.fixtures.dataklasses import GreetingTuple
 from hopscotch.operators import Get
 from hopscotch.operators import Operator
-
-import pytest
 
 
 @pytest.mark.parametrize(
@@ -150,6 +150,7 @@ def test_target_field_info_str(
     assert field_infos[0].field_name == "salutation"
     assert field_infos[0].field_type == str
     assert field_infos[0].default_value is None
+    assert field_infos[0].default_factory is None
     assert field_infos[0].has_annotated is False
 
 
@@ -170,6 +171,18 @@ def test_field_info_children(
     assert field_infos[0].field_name == "children"
     assert field_infos[0].field_type is None
     assert field_infos[0].default_value is None
+
+
+def test_field_info_default_value() -> None:
+    """Confirm a default value."""
+    field_infos = get_dataclass_field_infos(dataklasses.GreetingFieldDefault)
+    assert field_infos[0].default_value == "Default Argument"
+
+
+def test_field_info_default_factory() -> None:
+    """Confirm a default factory."""
+    field_infos = get_dataclass_field_infos(dataklasses.GreetingFieldDefaultFactory)
+    assert field_infos[0].default_factory is list
 
 
 def test_dataclass_field_info_init_false() -> None:

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -4,6 +4,7 @@ The ``inject_callable`` callable is used in both the registry and
 components. Thus it needs to support use both with and without a
 registry.
 """
+import pytest
 from hopscotch import Registry
 from hopscotch.fixtures import functions
 from hopscotch.fixtures import named_tuples
@@ -15,18 +16,32 @@ from hopscotch.fixtures.dataklasses import GreeterKind
 from hopscotch.fixtures.dataklasses import GreeterRegistry
 from hopscotch.fixtures.dataklasses import Greeting
 from hopscotch.fixtures.dataklasses import GreetingFactory
+from hopscotch.fixtures.dataklasses import GreetingFieldDefault
+from hopscotch.fixtures.dataklasses import GreetingFieldDefaultFactory
 from hopscotch.fixtures.dataklasses import GreetingNoDefault
 from hopscotch.registry import inject_callable
 from hopscotch.registry import Registration
 
-import pytest
-
 
 def test_field_default() -> None:
-    """The target a field with a default."""
+    """The target is a field with a default."""
     registration = Registration(Greeting)
     result: Greeting = inject_callable(registration)
     assert result.salutation == "Hello"
+
+
+def test_field_default_argument() -> None:
+    """The target is a field using a default argument."""
+    registration = Registration(GreetingFieldDefault)
+    result: Greeting = inject_callable(registration)
+    assert result.salutation == "Default Argument"
+
+
+def test_field_default_factory() -> None:
+    """The target is a field using a default factory."""
+    registration = Registration(GreetingFieldDefaultFactory)
+    result: Greeting = inject_callable(registration)
+    assert result.salutation == []
 
 
 def test_dependency_class() -> None:

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1,13 +1,14 @@
 """Test the bundled operators."""
 from dataclasses import dataclass
-from hopscotch import Registry
-from hopscotch.fixtures.dataklasses import Greeting
-from hopscotch.operators import Context
-from hopscotch.operators import Get
-from hopscotch.operators import make_field_operator
 from typing import Annotated
 
 import pytest
+from hopscotch import Registry
+from hopscotch.fixtures.dataklasses import Greeting
+from hopscotch.operators import Context
+from hopscotch.operators import context
+from hopscotch.operators import Get
+from hopscotch.operators import make_field_operator
 
 
 def test_get_setup() -> None:
@@ -109,10 +110,7 @@ def test_operators_context_attr() -> None:
 
     @dataclass
     class DummyHeading:
-        context_title: Annotated[
-            str,
-            Context(attr="title"),  # noqa: F821
-        ]
+        context_title: str = context(attr="title")
 
     context1 = Context1()
     registry = Registry(context=context1)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,5 +1,8 @@
 """Test the registry implementation and helpers."""
 from dataclasses import dataclass
+from typing import Optional
+
+import pytest
 from hopscotch import Registry
 from hopscotch.fixtures.dataklasses import AnotherGreeting
 from hopscotch.fixtures.dataklasses import Customer
@@ -12,9 +15,6 @@ from hopscotch.fixtures.dataklasses import Greeting
 from hopscotch.operators import context
 from hopscotch.registry import IsNoneType
 from hopscotch.registry import Registration
-from typing import Optional
-
-import pytest
 
 
 class DummyScan:


### PR DESCRIPTION
Dataclass fields with a default argument were supported, but not those with a default_factory.