### PR TITLE
Bring back hopscotch_setup

### DIFF
--- a/src/hopscotch/fixtures/hopscotch_setup/__init__.py
+++ b/src/hopscotch/fixtures/hopscotch_setup/__init__.py
@@ -1,0 +1,17 @@
+"""Package wants to manually setup the registry."""
+from dataclasses import dataclass
+
+from hopscotch import Registry
+
+
+@dataclass
+class MyConfig:
+    """Example configuration class for this fake site."""
+
+    site_title: str
+
+
+def hopscotch_setup(registry: Registry) -> None:
+    """Manually configure the registry for this package."""
+    my_config = MyConfig(site_title="My Configuration")
+    registry.register(my_config)

--- a/src/hopscotch/registry.py
+++ b/src/hopscotch/registry.py
@@ -205,6 +205,15 @@ class Registry:
             self.context = context
         self.scanner = Scanner(registry=self)
 
+    def setup(
+        self,
+        pkg: PACKAGE = None,
+    ) -> None:
+        """Pass the registry to a package which has a setup function."""
+        setup_function = getattr(pkg, "hopscotch_setup", None)
+        if setup_function:
+            setup_function(self)
+
     def scan(
         self,
         pkg: PACKAGE = None,

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -557,3 +557,14 @@ def test_context_registration_no_context() -> None:
     registry.register(Greeting, context=Customer)
     with pytest.raises(LookupError):
         registry.get(Greeting)
+
+
+def test_registry_hopscotch_setup() -> None:
+    """Module has ``hopscotch_setup`` called by ``registry.setup``."""
+    from hopscotch.fixtures import hopscotch_setup
+    from hopscotch.fixtures.hopscotch_setup import MyConfig
+
+    registry = Registry()
+    registry.setup(hopscotch_setup)
+    my_config = registry.get(MyConfig)
+    assert my_config.site_title == "My Configuration"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -557,23 +557,3 @@ def test_context_registration_no_context() -> None:
     registry.register(Greeting, context=Customer)
     with pytest.raises(LookupError):
         registry.get(Greeting)
-
-
-# FIXME Bring this back when examples are back
-# def test_injector_registry_scan_pkg():
-#     from examples import d_decorators
-#
-#     registry = Registry()
-#     ds = DummyScan()
-#     registry.scanner.scan = ds
-#     registry.scan(d_decorators)
-#     if ds.called_with:
-#         assert "examples.d_decorators" == ds.called_with.__name__
-
-
-# def test_injector_registry_scan_string():
-#     registry = Registry()
-#     ds = DummyScan()
-#     registry.scanner.scan = ds
-#     registry.scan("examples.d_decorators")
-#     assert "examples.d_decorators" == ds.called_with.__name__  # type: ignore


### PR DESCRIPTION
Packages can have a setup function that is passed the registry.